### PR TITLE
Fix init I2C given different clock and initialize it in main.c

### DIFF
--- a/i2c.h
+++ b/i2c.h
@@ -14,9 +14,12 @@ extern "C" {
 #endif
 	
 /* TODO: setup i2c/twi */
-#define F_I2C			100000UL// clock i2c
+#define F_I2C			100000UL	// clock i2c
+#ifdef F_CPU
+#define F_CPU			16000000UL	//define the correct CPU clock if the user is using a different setting
+#endif
 #define PSC_I2C			1		// prescaler i2c
-#define SET_TWBR		(F_CPU/F_I2C-16UL)/(PSC_I2C*2UL)
+#define SET_TWBR			((F_CPU/F_I2C-16UL)/(PSC_I2C*2UL))
 
 #include <stdio.h>
 #include <avr/io.h>

--- a/main.c
+++ b/main.c
@@ -8,6 +8,9 @@ int main(void){
   float temperature = 0.0;
   float pressure = 0.0;
   float humidity = 0.0;
+
+  //init I2C
+  i2c_init();
   
   // init sensor
   bme280_init(0);


### PR DESCRIPTION
# Problem: 
The i2c_init() function was not being called in main, which was setting TWBR to a wrong value if a different value of clock was used (in my case, 8MHz)

# Solution:
Implemented i2c_init() and defined a standard value for F_CPU if the user is using a different value